### PR TITLE
fix(18032026): add return 0 to main and tidy whitespace

### DIFF
--- a/classes/18032026/cb_array_sum.c
+++ b/classes/18032026/cb_array_sum.c
@@ -10,7 +10,6 @@ void fill_array(int *arr, int size) {
     {
         *(arr + i) = N + i + 1;
     }
-    
 }
 
 void sum_array(int *arr, int size, long int *result_sum) {
@@ -38,17 +37,14 @@ int main () {
 
     // Free memory
     free(arr);
-    
+
     // Results
     double elapsed_time = (double) (clock() - start_time) / CLOCKS_PER_SEC;
-
 
     printf("Array Elements: %d\n", N);
     printf("Total Sum: %ld\n", result_sum);
     printf("Elapsed Time: %.3fsg\n", elapsed_time);
 
-
-
-
-
+    // add return 0 for successful execution
+    return 0;
 }


### PR DESCRIPTION
This pull request makes a minor improvement to the `cb_array_sum.c` file by ensuring the `main` function returns `0` to indicate successful execution.

- Code quality and correctness:
  * Added a `return 0;` statement at the end of the `main` function to explicitly signal successful program termination (`cb_array_sum.c`).